### PR TITLE
Add header for ad7150

### DIFF
--- a/hw/misc/ad7150.c
+++ b/hw/misc/ad7150.c
@@ -330,7 +330,7 @@ static const VMStateDescription vmstate_ad7150 = {
     .post_load = ad7150_post_load,
     .fields = (VMStateField[]) {
         VMSTATE_UINT8(len, AD7150State),
-        VMSTATE_UINT8_ARRAY(buf, AD7150State, 0x18),
+        VMSTATE_UINT8_ARRAY(buf, AD7150State, 2),
         VMSTATE_UINT8(pointer, AD7150State),
         VMSTATE_I2C_SLAVE(i2c, AD7150State),
         VMSTATE_END_OF_LIST()

--- a/hw/misc/ad7150.h
+++ b/hw/misc/ad7150.h
@@ -1,0 +1,31 @@
+#ifndef QEMU_AD7150_H
+#define QEMU_AD7150_H
+
+#include "hw/irq.h"
+#include "hw/i2c/i2c.h"
+#include "qom/object.h"
+
+#define TYPE_AD7150 "ad7150"
+OBJECT_DECLARE_SIMPLE_TYPE(AD7150State, AD7150)
+
+struct AD7150State {
+    /*< private >*/
+    I2CSlave i2c;
+    /*< public >*/
+
+    uint8_t len;
+    uint8_t buf[2];
+    qemu_irq *pin;
+
+    uint8_t pointer;
+    uint8_t config;
+    int16_t temperature;
+    int64_t cap[2];
+    uint64_t cap_avg[2];
+    uint64_t sensitivity_or_thresh_high[2];
+    uint64_t timeout_or_thresh_low[2];
+    bool pwrdwn;
+    bool out[2]; 
+};
+
+#endif


### PR DESCRIPTION
Guess you may have forgotten to add the header file for ad7150.
I came up with this one for an alternative.
There's also an adjustment to the ad7150 buffer which is small enough to make me feel lazy about splitting the commit.

Still this doesn't work on my setup. Qemu exits with a segfault when trying to create the ad7150 device with `i2c_slave_create_simple()`. For now, I commented out the ad7150 stuff to play with ad7280a emulation.
I'm using the image you suggested on the mailing list with a mostly equal launch string except I'm also passing the initrd file I found inside the nocloud image.
I'll probably give ad7150 emulation a break to have look at the ad7280 patches. Nevertheless, I'm keen to try suggestions for the ad7150 emulation. :-)